### PR TITLE
return empty tab obj instead of null

### DIFF
--- a/extension/Userscripts Extension/Resources/background.js
+++ b/extension/Userscripts Extension/Resources/background.js
@@ -795,7 +795,7 @@ browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
                 } catch (error) {
                     console.error("failed to parse tab data for getTab");
                 }
-                sendResponse(tab);
+                sendResponse(tab == null ? {} : tab);
             } else {
                 console.error("unable to deliver tab due to empty tab id");
                 sendResponse(null);


### PR DESCRIPTION
TamperMonkey won't return null if the tab is not set before. I think we need to align with its behavior.