### PR TITLE
refactor: commit 24495ca of #268

### DIFF
--- a/extension/Userscripts Extension/Resources/content.js
+++ b/extension/Userscripts Extension/Resources/content.js
@@ -108,12 +108,9 @@ function injectCSS(name, code) {
     // browser.runtime.sendMessage({name: "API_ADD_STYLE_SYNC", css: code});
 
     // write the css code to head of the document
-    let wrapper = "const tag = document.createElement(\"style\");\n";
-    wrapper += `tag.textContent = \`${code}\`;`;
-    wrapper += "\ndocument.head.appendChild(tag);";
-    // execute the code directly into the context of the content script (not page context)
-    // wrapper += "console.log(window.browser)"; // this validates the execution env
-    return Function(wrapper)();
+    const tag = document.createElement("style");
+    tag.textContent = code;
+    document.head.appendChild(tag);
 }
 
 function cspFallback(e) {


### PR DESCRIPTION
For #268 commit [24495ca](https://github.com/quoid/userscripts/commit/24495caf45ba7a88165f25ed28071e22739da812), `wrapper` is not required to execute in the content script scope, so remove `wrapper` to execute the code directly.

NOTE: Injecting CSS using the method of adding page elements may still be blocked by the `CSP` policy.