### PR TITLE
Settings experience optimization

### DIFF
--- a/src/page/Components/Settings.svelte
+++ b/src/page/Components/Settings.svelte
@@ -19,7 +19,7 @@
 
     function saveBlacklist() {
         // get the comma separated values from blacklist input
-        const val = blacklist.value.split(",").map(item => item.trim()).filter(n => n);
+        const val = [...new Set(blacklist.value.split(",").map(item => item.trim()).filter(n => n))];
 
         // check if val matches `match patterns`, if not, return a warning
         const re = /^(http:|https:|\*:)\/\/((?:\*\.)?(?:[a-z0-9-]+\.)+(?:[a-z0-9]+)|\*\.[a-z]+|\*|[a-z0-9]+)(\/[^\s]*)$/;

--- a/src/page/Components/Settings.svelte
+++ b/src/page/Components/Settings.svelte
@@ -11,6 +11,8 @@
     let blacklist;
     // indicates that a blacklist save has initiated
     let blacklistSaving = false;
+    // indicates that a blacklist value has error
+    let blacklist_error = false;
 
     // the saved blacklisted domain patterns
     $: blacklisted = $settings.blacklist.join(", ");
@@ -18,6 +20,16 @@
     function saveBlacklist() {
         // get the comma separated values from blacklist input
         const val = blacklist.value.split(",").map(item => item.trim()).filter(n => n);
+
+        // check if val matches `match patterns`, if not, return a warning
+        const re = /^(http:|https:|\*:)\/\/((?:\*\.)?(?:[a-z0-9-]+\.)+(?:[a-z0-9]+)|\*\.[a-z]+|\*|[a-z0-9]+)(\/[^\s]*)$/;
+        for (const v of val) {
+            if (re.exec(v) === null) {
+                blacklist_error = true;
+                return console.warn("Global blacklist has wrong pattern:", v);
+            }
+        }
+        blacklist_error = false;
 
         // compare blacklist input to saved blacklist
         if ([...val].sort().toString() !== [...$settings.blacklist].sort().toString()) {
@@ -152,6 +164,7 @@
                     { #if blacklistSaving}{@html iconLoader}{/if}
                 </div>
                 <textarea
+                    class:error={blacklist_error}
                     placeholder="Comma separated list of @match patterns"
                     spellcheck="false"
                     bind:this={blacklist}
@@ -281,6 +294,10 @@
         padding: 0.5rem;
         width: 100%;
         min-width: 100%;
+    }
+
+    textarea.error {
+        border: 1px solid red;
     }
 
     textarea:focus {

--- a/src/page/Components/Settings.svelte
+++ b/src/page/Components/Settings.svelte
@@ -12,7 +12,7 @@
     // indicates that a blacklist save has initiated
     let blacklistSaving = false;
     // indicates that a blacklist value has error
-    let blacklist_error = false;
+    let blacklistError = false;
 
     // the saved blacklisted domain patterns
     $: blacklisted = $settings.blacklist.join(", ");
@@ -25,11 +25,11 @@
         const re = /^(http:|https:|\*:)\/\/((?:\*\.)?(?:[a-z0-9-]+\.)+(?:[a-z0-9]+)|\*\.[a-z]+|\*|[a-z0-9]+)(\/[^\s]*)$/;
         for (const v of val) {
             if (re.exec(v) === null) {
-                blacklist_error = true;
+                blacklistError = true;
                 return console.warn("Global blacklist has wrong pattern:", v);
             }
         }
-        blacklist_error = false;
+        blacklistError = false;
 
         // compare blacklist input to saved blacklist
         if ([...val].sort().toString() !== [...$settings.blacklist].sort().toString()) {
@@ -159,12 +159,12 @@
                 />
             </div>
             <div class="modal__row modal__row--wrap">
-                <div class="blacklist">
+                <div class="blacklist" class:red={blacklistError}>
                     <span>Global Blacklist</span>
                     { #if blacklistSaving}{@html iconLoader}{/if}
                 </div>
                 <textarea
-                    class:error={blacklist_error}
+                    class:error={blacklistError}
                     placeholder="Comma separated list of @match patterns"
                     spellcheck="false"
                     bind:this={blacklist}
@@ -297,7 +297,7 @@
     }
 
     textarea.error {
-        border: 1px solid red;
+        border: 1px solid var(--color-red);
     }
 
     textarea:focus {

--- a/src/page/Components/Settings.svelte
+++ b/src/page/Components/Settings.svelte
@@ -280,6 +280,7 @@
         opacity: 0.75;
         padding: 0.5rem;
         width: 100%;
+        min-width: 100%;
     }
 
     textarea:focus {

--- a/src/page/Components/Settings.svelte
+++ b/src/page/Components/Settings.svelte
@@ -68,7 +68,7 @@
 
 <div
     class="settings"
-    on:click|self={() => state.remove("settings")}
+    on:mousedown|self={() => state.remove("settings")}
     in:fade={{duration: 150}}
     out:fade={{duration: 150, delay: 75}}
 >


### PR DESCRIPTION
This PR contains the changes from https://github.com/quoid/userscripts/pull/339 and adds a new fix:

- Fixed incorrect close action caused by clicking and releasing areas for the [following reasons.](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)

> If the button is pressed on one element and the pointer is moved outside the element before the button is released, the event is fired on the most specific ancestor element that contained both elements.


https://user-images.githubusercontent.com/101378590/194432823-cbb7eadb-f6e4-43a1-b45d-40552e156c9d.mp4

https://user-images.githubusercontent.com/101378590/194432839-4fbdc4a3-aade-4b0e-9a82-96cd3799cc36.mp4


