### PR TITLE
Rename `Preferences` to `Settings`

### DIFF
--- a/xcode/Mac-App/Base.lproj/View.storyboard
+++ b/xcode/Mac-App/Base.lproj/View.storyboard
@@ -163,7 +163,7 @@
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vjm-rq-99e">
                                         <rect key="frame" x="152" y="-7" width="156" height="27"/>
-                                        <buttonCell key="cell" type="push" title="Open Safari Settings" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gl1-ZS-OQH">
+                                        <buttonCell key="cell" type="push" title="Open Safari Extensions list" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gl1-ZS-OQH">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
                                         </buttonCell>

--- a/xcode/Mac-App/Base.lproj/View.storyboard
+++ b/xcode/Mac-App/Base.lproj/View.storyboard
@@ -163,7 +163,7 @@
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vjm-rq-99e">
                                         <rect key="frame" x="152" y="-7" width="156" height="27"/>
-                                        <buttonCell key="cell" type="push" title="Open Safari Preferences" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gl1-ZS-OQH">
+                                        <buttonCell key="cell" type="push" title="Open Safari Settings" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gl1-ZS-OQH">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
                                         </buttonCell>


### PR DESCRIPTION
`Preferences` became `Settings` in macOS Ventura: https://9to5mac.com/2022/11/01/mac-system-settings-macos-ventura/
