### PR TITLE
chore: update open button text for macOS 13+

### DIFF
--- a/xcode/Mac-App/Base.lproj/View.storyboard
+++ b/xcode/Mac-App/Base.lproj/View.storyboard
@@ -85,7 +85,7 @@
                                 </textFieldCell>
                             </textField>
                             <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pKD-4w-JK7">
-                                <rect key="frame" x="144" y="24" width="192" height="16"/>
+                                <rect key="frame" x="144" y="24" width="193" height="16"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Pik-Ho-vD1">
                                         <rect key="frame" x="-2" y="2" width="78" height="12"/>
@@ -107,7 +107,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WiE-Qy-xne">
-                                        <rect key="frame" x="129" y="-7" width="69" height="27"/>
+                                        <rect key="frame" x="129" y="-7" width="70" height="27"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="57" id="KfI-LD-AaS"/>
                                         </constraints>
@@ -204,6 +204,7 @@
                         <outlet property="appName" destination="gGD-M9-Dwj" id="WOi-mP-IbI"/>
                         <outlet property="enabledIcon" destination="i4K-xO-vlx" id="M8i-Qj-l6w"/>
                         <outlet property="enabledText" destination="v0r-qO-55O" id="wNQ-gC-2zf"/>
+                        <outlet property="openButton" destination="vjm-rq-99e" id="Mc0-Do-3jr"/>
                         <outlet property="saveLocation" destination="6k5-Oz-mOV" id="pgz-od-dyH"/>
                     </connections>
                 </viewController>

--- a/xcode/Mac-App/ViewController.swift
+++ b/xcode/Mac-App/ViewController.swift
@@ -7,7 +7,8 @@ class ViewController: NSViewController {
     @IBOutlet var saveLocation: NSTextField!
     @IBOutlet weak var enabledText: NSTextField!
     @IBOutlet weak var enabledIcon: NSView!
-
+	@IBOutlet weak var openButton: NSButton!
+	
     let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "??"
     let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "??"
     let extensionID = extensionIdentifier
@@ -22,10 +23,12 @@ class ViewController: NSViewController {
             name: NSApplication.didBecomeActiveNotification,
             object: nil
         )
-        // set the save location url display
         let url = getSaveLocationURL()
         self.saveLocation.stringValue = url.absoluteString
         self.saveLocation.toolTip = url.absoluteString
+		if #available(macOS 13, *) {
+			self.openButton.title = "Open Safari Settings"
+		}
     }
 
     @objc func setExtensionState() {


### PR DESCRIPTION
This PR simply updates the button text on the "open button" within the Mac App for users one macOS 13+. This is an alternative method that was originally mentioned in this PR: https://github.com/quoid/userscripts/pull/441