### PR TITLE
fix(popup): update item background color on mouse hover

### DIFF
--- a/src/popup/App.svelte
+++ b/src/popup/App.svelte
@@ -14,7 +14,7 @@
     import iconRefresh from "../shared/img/icon-refresh.svg?raw";
     import {extensionPaths, openExtensionPage} from "../shared/utils.js";
     import * as settingsStorage from "../shared/settings.js";
-    
+
     let errorNotification;
     let active = true;
     let loading = true;
@@ -45,15 +45,14 @@
 
     $: list = items.sort((a, b) => a.name.localeCompare(b.name));
 
-    $: if (list.length > 1 && list.length % 2 === 0) {
-        rowColors = "even";
-    } else if (list.length > 1 && list.length % 2 !== 0) {
-        rowColors = "odd";
-    } else {
-        rowColors = undefined;
-    }
-
     $: if (platform) document.body.classList.add(platform);
+
+    function getItemBackgroundColor(elements, index) {
+        if (elements.length < 2) return null;
+        if (elements.length % 2 === 0 && index % 2 === 0) return "light";
+        if (elements.length % 2 !== 0 && index % 2 !== 0) return "light";
+        return null;
+    }
 
     async function toggleExtension() {
         await settingsStorage.set({global_active: !active});
@@ -555,8 +554,9 @@
             <div class="none">No matched userscripts</div>
         {:else}
             <div class="items" class:disabled={disabled}>
-                {#each list as item (item.filename)}
+                {#each list as item, i (item.filename)}
                     <PopupItem
+                        background={getItemBackgroundColor(list, i)}
                         enabled={!item.disabled}
                         name={item.name}
                         subframe={item.subframe}
@@ -699,11 +699,6 @@
 
     :global(body:not(.ios) .main) {
         max-height: 20rem;
-    }
-
-    .main.even :global(.item:nth-of-type(odd)),
-    .main.odd :global(.item:nth-of-type(even)) {
-        background-color: var(--color-bg-primary);
     }
 
     .none {

--- a/src/popup/Components/PopupItem.svelte
+++ b/src/popup/Components/PopupItem.svelte
@@ -8,7 +8,7 @@
     export let request = false;
 </script>
 
-<div class="item self {enabled ? "enabled" : "disabled"}" on:click>
+<div class="item {enabled ? "enabled" : "disabled"}" on:click>
     <span></span>
     <div class="truncate">{name}</div>
     {#if subframe}<div class="subframe">SUB</div>{/if}
@@ -27,12 +27,12 @@
     }
 
     @media (hover: hover) {
-        .item.self:hover {
+        .item.item:hover {
             background-color: rgb(255 255 255 / 0.075);
         }
     }
 
-    .item.self:active {
+    .item.item:active {
         background-color: rgb(255 255 255 / 0.15);
     }
 

--- a/src/popup/Components/PopupItem.svelte
+++ b/src/popup/Components/PopupItem.svelte
@@ -30,10 +30,6 @@
         user-select: none;
     }
 
-    .item:active {
-        background-color: rgb(255 255 255 / 0.15);
-    }
-
     .item.light {
         background-color: var(--color-bg-primary);
     }
@@ -42,6 +38,10 @@
         .item:hover {
             background-color: rgb(255 255 255 / 0.075);
         }
+    }
+
+    .item:active {
+        background-color: rgb(255 255 255 / 0.15);
     }
 
     span {

--- a/src/popup/Components/PopupItem.svelte
+++ b/src/popup/Components/PopupItem.svelte
@@ -8,7 +8,7 @@
     export let request = false;
 </script>
 
-<div class="item {enabled ? "enabled" : "disabled"}" on:click>
+<div class="item self {enabled ? "enabled" : "disabled"}" on:click>
     <span></span>
     <div class="truncate">{name}</div>
     {#if subframe}<div class="subframe">SUB</div>{/if}
@@ -27,12 +27,12 @@
     }
 
     @media (hover: hover) {
-        .item:hover {
+        .item.self:hover {
             background-color: rgb(255 255 255 / 0.075);
         }
     }
 
-    .item:active {
+    .item.self:active {
         background-color: rgb(255 255 255 / 0.15);
     }
 

--- a/src/popup/Components/PopupItem.svelte
+++ b/src/popup/Components/PopupItem.svelte
@@ -1,6 +1,7 @@
 <script>
     import Tag from "../../shared/Components/Tag.svelte";
-    
+
+    export let background;
     export let enabled = false;
     export let name;
     export let type;
@@ -8,7 +9,10 @@
     export let request = false;
 </script>
 
-<div class="item {enabled ? "enabled" : "disabled"}" on:click>
+<div
+    class="item {enabled ? "enabled" : "disabled"} {background ?? ""}"
+    on:click
+>
     <span></span>
     <div class="truncate">{name}</div>
     {#if subframe}<div class="subframe">SUB</div>{/if}
@@ -26,14 +30,18 @@
         user-select: none;
     }
 
-    @media (hover: hover) {
-        .item.item:hover {
-            background-color: rgb(255 255 255 / 0.075);
-        }
+    .item:active {
+        background-color: rgb(255 255 255 / 0.15);
     }
 
-    .item.item:active {
-        background-color: rgb(255 255 255 / 0.15);
+    .item.light {
+        background-color: var(--color-bg-primary);
+    }
+
+    @media (hover: hover) {
+        .item:hover {
+            background-color: rgb(255 255 255 / 0.075);
+        }
     }
 
     span {


### PR DESCRIPTION
https://github.com/quoid/userscripts/blob/5f513191c4a61baecce4564ea843401178a73678/src/popup/Components/PopupItem.svelte#L29-L37

https://github.com/quoid/userscripts/blob/5f513191c4a61baecce4564ea843401178a73678/src/popup/App.svelte#L704-L707

Since the above two original CSS selectors have the same priority, they can only be determined by order. And the new way of building seems to change the order of the generated CSS, causing the breakage. Ensures independence from CSS order by specifying explicitly and incrementing the priority counter.

| Broken | Fixed |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/101378590/224085089-6269a336-cf32-4897-a5b3-96bfa4f04f00.mp4"></video> | <video src="https://user-images.githubusercontent.com/101378590/224085175-e689c5c2-cf0e-4788-ae9a-3e62e5e4dbac.mp4"></video> |
