### PR TITLE
refactor: update style rules to use shorthand prop

### DIFF
--- a/src/popup/App.svelte
+++ b/src/popup/App.svelte
@@ -703,15 +703,12 @@
 
     .none {
         align-items: center;
-        bottom: 0;
         color: var(--text-color-disabled);
         display: flex;
         font-weight: 600;
         justify-content: center;
-        left: 0;
+        inset: 0;
         position: absolute;
-        right: 0;
-        top: 0;
     }
 
     .items.disabled {

--- a/src/popup/Components/Views/AllItemsView.svelte
+++ b/src/popup/Components/Views/AllItemsView.svelte
@@ -48,14 +48,11 @@
 
     .none {
         align-items: center;
-        bottom: 0;
         color: var(--text-color-disabled);
         display: flex;
         font-weight: 600;
         justify-content: center;
-        left: 0;
+        inset: 0;
         position: absolute;
-        right: 0;
-        top: 0;
     }
 </style>

--- a/src/shared/Components/Loader.svelte
+++ b/src/shared/Components/Loader.svelte
@@ -19,14 +19,11 @@
 <style>
     .loader {
         align-items: center;
-        bottom: 0;
         display: flex;
         flex-direction: column;
         justify-content: center;
-        left: 0;
+        inset: 0;
         position: absolute;
-        right: 0;
-        top: 0;
         z-index: 90;
     }
 


### PR DESCRIPTION
Stylelint is complaining about this error: [`declaration-block-no-redundant-longhand-properties`](https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties/). Interestingly we never had this error show up before and even when it is toggled to `true` locally no errors show up...

This addresses the errors but does not address the issue of the errors not showing locally. That needs to be done as well or we need to remove Stylelint from the ci.