### PR TITLE
fix: update permission for `declarativeNetRequest`

### DIFF
--- a/xcode/Safari-Extension/Resources/manifest.json
+++ b/xcode/Safari-Extension/Resources/manifest.json
@@ -35,6 +35,7 @@
         "<all_urls>",
         "clipboardWrite",
         "contextMenus",
+        "declarativeNetRequest",
         "declarativeNetRequestWithHostAccess",
         "menus",
         "nativeMessaging",


### PR DESCRIPTION
Due to [changes in Safari 16.4](https://webkit.org/blog/13966/webkit-features-in-safari-16-4/#enhancements-to-declarative-net-request):
> The `redirect` action type now requires the `declarativeNetRequestWithHostAccess` permission in the manifest.

Updating the corresponding permission in `manifest.json` will fix #457.