### PR TITLE
fix: properly discharge xhr resources

### DIFF
--- a/xcode/Safari-Extension/Resources/background.js
+++ b/xcode/Safari-Extension/Resources/background.js
@@ -424,7 +424,7 @@ function handleMessage(request, sender, sendResponse) {
             });
             // handle port disconnect and clean tasks
             port.onDisconnect.addListener(p => {
-                if (p.error) {
+                if (p?.error) {
                     console.error(`port disconnected due to an error: ${p.error.message}`);
                 }
             });

--- a/xcode/Safari-Extension/Resources/content.js
+++ b/xcode/Safari-Extension/Resources/content.js
@@ -178,11 +178,11 @@ const apis = {
                     }
                     // call userscript method
                     details[msg.name](msg.response);
-                    // all messages received
-                    // tell background it's safe to close port
-                    if (msg.name === "onloadend") {
-                        port.postMessage({name: "DISCONNECT"});
-                    }
+                }
+                // all messages received
+                // tell background it's safe to close port
+                if (msg.name === "onloadend") {
+                    port.postMessage({name: "DISCONNECT"});
                 }
             });
 

--- a/xcode/Safari-Extension/Resources/content.js
+++ b/xcode/Safari-Extension/Resources/content.js
@@ -188,7 +188,7 @@ const apis = {
 
             // handle port disconnect and clean tasks
             port.onDisconnect.addListener(p => {
-                if (p.error) {
+                if (p?.error) {
                     console.error(`port disconnected due to an error: ${p.error.message}`);
                 }
                 browser.runtime.onConnect.removeListener(listener);


### PR DESCRIPTION
The listener for the xhr port in the content script was not properly removed. This can lead to significant resource usage in heavy request scenarios.