### PR TITLE
fix: disable dnr below safari 15.4

### DIFF
--- a/xcode/Safari-Extension/Resources/background.js
+++ b/xcode/Safari-Extension/Resources/background.js
@@ -130,6 +130,8 @@ async function setBadgeCount() {
 }
 
 async function setSessionRules() {
+    // not supported below safari 15.4
+    if (!browser.declarativeNetRequest.updateSessionRules) return;
     await clearAllSessionRules();
     const message = {name: "REQ_REQUESTS"};
     const response = await browser.runtime.sendNativeMessage(message);


### PR DESCRIPTION
```console
[Error] Unhandled Promise Rejection: TypeError: browser.declarativeNetRequest.getSessionRules is not a function.
```

Because [`getSessionRules`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/getSessionRules) and [`updateSessionRules`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/updateSessionRules)  of declarativeNetRequest are not supported before Safari 15.4, it will cause errors in background script. Check and disable this feat.