### PR TITLE
fix: update rules when toggle dnr item

### DIFF
--- a/src/page/Components/Sidebar/Sidebar.svelte
+++ b/src/page/Components/Sidebar/Sidebar.svelte
@@ -146,6 +146,10 @@
                     ind.disabled = !ind.disabled;
                     return allItems;
                 });
+                if (item.request) {
+                    // refresh session rules
+                    browser.runtime.sendMessage({name: "REFRESH_SESSION_RULES"});
+                }
             } else {
                 log.add("Failed to toggle item", "error", true);
             }


### PR DESCRIPTION
Fix the issue where switch off a dnr item in the extention page does not take effect.