### PR TITLE
refactor(logger): reduce disk writes and improve privacy

### DIFF
--- a/xcode/Mac-App/Functions.swift
+++ b/xcode/Mac-App/Functions.swift
@@ -1,7 +1,9 @@
 import AppKit
 import SafariServices
+import os
 
 let extensionIdentifier = Bundle.main.infoDictionary?["US_EXT_IDENTIFIER"] as! String
+fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: #fileID)
 
 func getSaveLocationURL() -> URL {
     var url: URL
@@ -41,7 +43,7 @@ func setSaveLocationURL(url: URL) -> Bool {
         return false
     }
     guard saveBookmark(url: url, isShared: true, keyName: SharedDefaults.keyName, isSecure: false) else {
-        err("couldn't save new location from host app")
+        logger.error("\(#function, privacy: .public) - couldn't save new location from host app")
         return false
     }
     return true

--- a/xcode/Mac-App/ViewController.swift
+++ b/xcode/Mac-App/ViewController.swift
@@ -1,5 +1,8 @@
 import Cocoa
 import SafariServices.SFSafariApplication
+import os
+
+fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: #fileID)
 
 class ViewController: NSViewController {
 
@@ -33,9 +36,13 @@ class ViewController: NSViewController {
 
     @objc func setExtensionState() {
         SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: extensionID) { (state, error) in
-            guard let state = state, error == nil else {
+            guard let state = state else {
                 self.enabledText.stringValue = "Safari Extension State Unknown"
-                err(error?.localizedDescription ?? "couldn't get safari extension state in containing app")
+                if let error = error {
+                    logger.error("\(#function, privacy: .public) - \(error.localizedDescription, privacy: .public)")
+                } else {
+                    logger.error("\(#function, privacy: .public) - couldn't get safari extension state in containing app")
+                }
                 return
             }
             DispatchQueue.main.async {

--- a/xcode/Safari-Extension/SafariWebExtensionHandler.swift
+++ b/xcode/Safari-Extension/SafariWebExtensionHandler.swift
@@ -1,15 +1,17 @@
 import SafariServices
+import os
 
 class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
     func beginRequest(with context: NSExtensionContext) {
+        let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: #fileID)
         let item = context.inputItems[0] as? NSExtensionItem
         let message = item?.userInfo?[SFExtensionMessageKey] as? [String: Any]
         // if message received without name, ignore
         guard let name = message?["name"] as? String else {
-            err("could not get message name from web extension")
+            logger.error("\(#function, privacy: .public) - could not get message name from web extension")
             return
         }
-        logText("Got message with name: \(name)")
+        logger.info("\(#function, privacy: .public) - Got message with name: \(name, privacy: .public)")
         // got a valid message, construct response based on message received
         let response = NSExtensionItem()
         // send standard error when there's an issue parsing inbound message

--- a/xcode/Shared/Shared.swift
+++ b/xcode/Shared/Shared.swift
@@ -2,6 +2,8 @@ import Foundation
 import SafariServices
 import os
 
+fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: #fileID)
+
 struct SharedDefaults {
     // https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_application-groups
     static let suiteName = Bundle.main.infoDictionary?["US_SHARED_GID"] as? String
@@ -10,18 +12,6 @@ struct SharedDefaults {
     #elseif os(macOS)
         static let keyName = "hostSelectedSaveLocation"
     #endif
-}
-
-func err(_ message: String) {
-    let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "general")
-    os_log("%{public}@", log: log, type: .error, "Error: \(message)")
-}
-
-func logText(_ message: String) {
-    // create helper log func to easily disable logging
-    // NSLog(message)
-    let log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "general")
-    os_log("%{public}@", log: log, type: .default, message)
 }
 
 func getDocumentsDirectory() -> URL {
@@ -76,7 +66,7 @@ func saveBookmark(url: URL, isShared: Bool, keyName: String, isSecure: Bool) -> 
         #endif
         return true
     } catch let error {
-        err("\(error)")
+        logger.error("\(#function, privacy: .public) - \(error, privacy: .public)")
         return false
     }
 }
@@ -105,7 +95,7 @@ func readBookmark(data: Data, isSecure: Bool) -> URL? {
         }
         return url
     } catch let error {
-        err("Error: \(error)")
+        logger.error("\(#function, privacy: .public) - \(error, privacy: .public)")
         return nil
     }
 }

--- a/xcode/iOS-App/ViewController.swift
+++ b/xcode/iOS-App/ViewController.swift
@@ -9,6 +9,9 @@
 import UIKit
 import WebKit
 import UniformTypeIdentifiers
+import os
+
+fileprivate let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: #fileID)
 
 class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler, UIDocumentPickerDelegate {
 
@@ -61,11 +64,11 @@ class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHan
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard let name = message.body as? String else {
-            err("Userscripts iOS received a message without a name")
+            logger.error("\(#function, privacy: .public) - Userscripts iOS received a message without a name")
             return
         }
         if name == "SET_READ_LOCATION" {
-            logText("Userscripts iOS has requested to set the readLocation")
+            logger.info("\(#function, privacy: .public) - Userscripts iOS has requested to set the readLocation")
             let documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: [.folder])
             documentPicker.delegate = self
             present(documentPicker, animated: true, completion: nil)
@@ -85,7 +88,7 @@ class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHan
                 throw NSError(domain: "Failed to saved bookmark", code: 0, userInfo: [:])
             }
         } catch let error {
-            err("\(error)")
+            logger.error("\(#function, privacy: .public) - \(error, privacy: .public)")
             return
         }
     }


### PR DESCRIPTION
- Migrate to structure [`Logger`](https://developer.apple.com/documentation/os/logger) from using the [Legacy Logging Symbols](https://developer.apple.com/documentation/os/logging/legacy_logging_symbols)
- Improve usage of [log levels](https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code#3665947) so that most logs will no longer be persisted to disk
- Improve log content and use the [privacy options](https://developer.apple.com/documentation/os/oslogprivacy) for dynamically generated data
- Improve dev and debug experience that can log more data types besides strings
- Use fileID to fill the log category to facilitate filtering, can be further refined in the future

Todo in future: add a setting to turn off by default to output logs only when user needed