### PR TITLE
chore: enable sourcemap for beta builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
 		"dev:ext-safari-ios": "SAFARI_PLATFORM=ios node scripts/dev-ext-safari.js",
 		"build:mac": "npm run build:app && npm run build:ext-safari-mac",
 		"build:ios": "npm run build:app && npm run build:ext-safari-ios",
+		"build:mac-beta": "npm run build:app && BETA=1 npm run build:ext-safari-mac",
+		"build:ios-beta": "npm run build:app && BETA=1 npm run build:ext-safari-ios",
 		"build:app": "node scripts/build-app.js",
 		"build:ext-safari-mac": "SAFARI_PLATFORM=mac node scripts/build-ext-safari-15.js",
 		"build:ext-safari-ios": "SAFARI_PLATFORM=ios node scripts/build-ext-safari-15.js",

--- a/scripts/build-ext-safari-15.js
+++ b/scripts/build-ext-safari-15.js
@@ -38,6 +38,7 @@ const defineConfig = {
 		),
 	},
 };
+const sourcemap = process.env.BETA ? true : false;
 
 /**
  * Empty resources directory
@@ -59,6 +60,7 @@ cp("public/ext/safari-15", SAFARI_EXT_RESOURCES);
 			outDir: `${SAFARI_EXT_RESOURCES}/dist/content-scripts/`,
 			emptyOutDir: false,
 			copyPublicDir: false,
+			sourcemap,
 			rollupOptions: {
 				input,
 				output: { entryFileNames: "[name].js" },
@@ -74,6 +76,7 @@ build({
 		outDir: `${SAFARI_EXT_RESOURCES}/dist/`,
 		emptyOutDir: false,
 		copyPublicDir: false,
+		sourcemap,
 		rollupOptions: {
 			input: { background: "src/ext/background/main.js" },
 			output: { entryFileNames: "[name].js" },
@@ -89,6 +92,7 @@ build({
 	build: {
 		outDir: `${SAFARI_EXT_RESOURCES}/dist/`,
 		emptyOutDir: false,
+		sourcemap,
 		rollupOptions: {
 			input: ["entry-ext-action-popup.html", "entry-ext-extension-page.html"],
 		},

--- a/scripts/build-ext-safari-16.4.js
+++ b/scripts/build-ext-safari-16.4.js
@@ -37,6 +37,7 @@ const defineConfig = {
 		),
 	},
 };
+const sourcemap = process.env.BETA ? true : false;
 
 /**
  * Empty resources directory
@@ -58,6 +59,7 @@ cp("public/ext/safari-16.4", SAFARI_EXT_RESOURCES);
 			outDir: `${SAFARI_EXT_RESOURCES}/dist/content-scripts/`,
 			emptyOutDir: false,
 			copyPublicDir: false,
+			sourcemap,
 			rollupOptions: {
 				input,
 				output: { entryFileNames: "[name].js" },
@@ -77,6 +79,7 @@ build({
 		outDir: `${SAFARI_EXT_RESOURCES}/dist/`,
 		emptyOutDir: false,
 		copyPublicDir: false,
+		sourcemap,
 		rollupOptions: {
 			input: { background: "src/ext/background/main.js" },
 			output: { entryFileNames: "[name].js" },
@@ -92,6 +95,7 @@ build({
 	build: {
 		outDir: `${SAFARI_EXT_RESOURCES}/dist/`,
 		emptyOutDir: false,
+		sourcemap,
 		rollupOptions: {
 			input: {
 				// background: "src/ext/background/main.js",


### PR DESCRIPTION
Add beta builds with [`sourcemap`](https://vitejs.dev/config/build-options.html#build-sourcemap) enabled to facilitate debugging of extension code for capable users.

Refer to: https://github.com/quoid/userscripts/issues/614#issuecomment-1913842534