### PR TITLE
ci: automatic build distribution to QA test group

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Set xcode version
         run: sudo xcode-select -s "/Applications/Xcode_15.4.app" # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
       - name: Run fastlane
+        id: fastlane
         working-directory: ./fastlane
         env:
           FASTLANE_OPT_OUT_USAGE: "YES"
@@ -63,5 +64,5 @@ jobs:
       - name: Artifact dSYM
         uses: actions/upload-artifact@v4 # https://github.com/actions/upload-artifact
         with:
-          name: Userscripts_${{ matrix.platform }}_${{ github.ref_name }}.app.dSYM
+          name: Userscripts_${{ matrix.platform }}_${{ steps.fastlane.outputs.ver || github.ref_name }}.app.dSYM
           path: build/*.dSYM.zip

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,9 @@ platform :ios do
 	lane :beta do
 		match
 		BUILD_NUMBER = latest_testflight_build_number(platform: "ios") + 1
+		File.open(ENV['GITHUB_OUTPUT'], 'a') do |file|
+			file.puts "ver=v#{ENV['MARKETING_VERSION']}(#{BUILD_NUMBER})"
+		end
 		build_app(
 			project: PROJECT_PATH,
 			scheme: "iOS",
@@ -58,6 +61,9 @@ platform :mac do
 	lane :beta do
 		match
 		BUILD_NUMBER = latest_testflight_build_number(platform: "osx") + 1
+		File.open(ENV['GITHUB_OUTPUT'], 'a') do |file|
+			file.puts "ver=v#{ENV['MARKETING_VERSION']}(#{BUILD_NUMBER})"
+		end
 		build_mac_app(
 			project: PROJECT_PATH,
 			scheme: "Mac",


### PR DESCRIPTION
All automated builds will undergo final testing by our QA Team before being distributed to the wider test group and the App Store to minimize any regressions and bugs that reach end users.

This PR adds that automated process to distribute builds directly to the QA test group.

At the same time, the artifact file name is optimized to make it more convenient to view the build version number.