### PR TITLE
refactor: use dynamic rules for dnr and improvements

### DIFF
--- a/src/ext/extension-page/Components/Editor/Editor.svelte
+++ b/src/ext/extension-page/Components/Editor/Editor.svelte
@@ -86,7 +86,7 @@
 			// set the newly saved file contents in codemirror instance
 			cmSetSavedCode(response.content);
 			// refresh session rules
-			browser.runtime.sendMessage({ name: "REFRESH_SESSION_RULES" });
+			browser.runtime.sendMessage({ name: "REFRESH_DNR_RULES" });
 			// refresh context-menu scripts
 			browser.runtime.sendMessage({ name: "REFRESH_CONTEXT_MENU_SCRIPTS" });
 		}

--- a/src/ext/extension-page/Components/Sidebar/Sidebar.svelte
+++ b/src/ext/extension-page/Components/Sidebar/Sidebar.svelte
@@ -177,7 +177,7 @@
 				});
 				if (item.request) {
 					// refresh session rules
-					browser.runtime.sendMessage({ name: "REFRESH_SESSION_RULES" });
+					browser.runtime.sendMessage({ name: "REFRESH_DNR_RULES" });
 				}
 			} else {
 				log.add("Failed to toggle item", "error", true);

--- a/src/ext/shared/dev.js
+++ b/src/ext/shared/dev.js
@@ -100,7 +100,7 @@ const _browser = {
 			const name = message.name;
 			console.info(`Got message: ${name}`);
 			let response = {};
-			if (name === "REFRESH_SESSION_RULES") {
+			if (name === "REFRESH_DNR_RULES") {
 				response = { success: true };
 			}
 			if (!responseCallback) {


### PR DESCRIPTION
Use `dynamic ruleset` instead of `session ruleset` to resolve #683.

Simply refactor the DNR adding process to improve fault tolerance and error handling.