### PR TITLE
fix: make `@grant none` work correctly

### DIFF
--- a/xcode/Ext-Safari/Functions.swift
+++ b/xcode/Ext-Safari/Functions.swift
@@ -1247,13 +1247,19 @@ func getCode(_ filenames: [String], _ isTop: Bool)-> [String: Any]? {
 
 		// attempt to get all @grant value
 		var grants = metadata["grant"] ?? []
-		// remove duplicates, if any exist
-		if !grants.isEmpty {
-			grants = Array(Set(grants))
-		}
 
-		// filter out grant values that are not in validGrant set
-		grants = grants.filter{validGrants.contains($0)}
+		if !grants.isEmpty {
+			if grants.contains("none") {
+				// `@grant none` takes precedence
+				grants = []
+			} else {
+				// remove duplicates
+				grants = Array(Set(grants))
+				// filter out grant values that are not in validGrant set
+				grants = grants.filter{validGrants.contains($0)}
+			}
+		}
+		
 
 		// set GM.info data
 		let description = metadata["description"]?[0] ?? ""


### PR DESCRIPTION
It looks like the bug was introduced in https://github.com/quoid/userscripts/commit/9c7066f70482cb432247b883a10a7b68d8dad3c6  that caused `@grant none` to actually be ignored.

Fix the issue so it works again.