### PR TITLE
feat(macos): do not open safari when change save location

### DIFF
--- a/xcode/App-Mac/ViewController.swift
+++ b/xcode/App-Mac/ViewController.swift
@@ -65,14 +65,16 @@ class ViewController: NSViewController {
 			// update user interface text display
 			self.saveLocation.stringValue = url.absoluteString
 			self.saveLocation.toolTip = url.absoluteString
-			// notify browser extension of relevant updates
-			sendExtensionMessage(
-				name: "SAVE_LOCATION_CHANGED",
-				userInfo: [
-					"saveLocation": url.absoluteString.removingPercentEncoding ?? url.absoluteString,
-					"returnApp": true
-				]
-			)
+			// notify browser extension of relevant updates only when Safari is running
+			if !NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.Safari").isEmpty {
+				sendExtensionMessage(
+					name: "SAVE_LOCATION_CHANGED",
+					userInfo: [
+						"saveLocation": url.absoluteString.removingPercentEncoding ?? url.absoluteString,
+						"returnApp": true
+					]
+				)
+			}
 		})
 	}
 


### PR DESCRIPTION
If Safari is not running, do not open it, only send messages to the extension when Safari is running.