### PR TITLE
fix: also checks if the user selected folder is readable

### DIFF
--- a/xcode/App-Mac/Functions.swift
+++ b/xcode/App-Mac/Functions.swift
@@ -10,13 +10,13 @@ func getSaveLocationURL() -> URL {
 func setSaveLocationURL(url: URL) -> Bool {
 	guard FileManager.default.isReadableFile(atPath: url.path) else {
 		let alert = NSAlert()
-		alert.messageText = "Can not read to path. Choose a different path."
+		alert.messageText = "Cannot read the specified path; please choose a different one."
 		alert.runModal()
 		return false
 	}
 	guard FileManager.default.isWritableFile(atPath: url.path) else {
 		let alert = NSAlert()
-		alert.messageText = "Can not write to path. Choose a different path."
+		alert.messageText = "Cannot write to the specified path; please choose a different one."
 		alert.runModal()
 		return false
 	}


### PR DESCRIPTION
Merely detecting writability is not enough, as the folder permissions may be "Write only (Drop Box)".