### PR TITLE
Revert "feat(macos): do not open safari when change save location"

### DIFF
--- a/xcode/App-Mac/ViewController.swift
+++ b/xcode/App-Mac/ViewController.swift
@@ -65,16 +65,14 @@ class ViewController: NSViewController {
 			// update user interface text display
 			self.saveLocation.stringValue = url.absoluteString
 			self.saveLocation.toolTip = url.absoluteString
-			// notify browser extension of relevant updates only when Safari is running
-			if !NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.Safari").isEmpty {
-				sendExtensionMessage(
-					name: "SAVE_LOCATION_CHANGED",
-					userInfo: [
-						"saveLocation": url.absoluteString.removingPercentEncoding ?? url.absoluteString,
-						"returnApp": true
-					]
-				)
-			}
+			// notify browser extension of relevant updates
+			sendExtensionMessage(
+				name: "SAVE_LOCATION_CHANGED",
+				userInfo: [
+					"saveLocation": url.absoluteString.removingPercentEncoding ?? url.absoluteString,
+					"returnApp": true
+				]
+			)
 		})
 	}
 


### PR DESCRIPTION
Reverts quoid/userscripts#731

Although tested it works and works fine.

> [Share file access between processes with URL bookmarks](https://developer.apple.com/documentation/security/accessing-files-from-the-macos-app-sandbox#Share-file-access-between-processes-with-URL-bookmarks)
> Foundation creates a URL bookmark with an implicit security scope that **lasts until your app exits**.

However, in order to avoid accidents, according to the documentation, ensure that the change are synchronized to the extension process before the App exits.