### PR TITLE
fix: basic repair context-menu script broken

### DIFF
--- a/src/ext/background/main.js
+++ b/src/ext/background/main.js
@@ -224,33 +224,7 @@ async function getContextMenuItems() {
 }
 
 async function addContextMenuItem(userscript) {
-	// context-menu items persist for a session
-	// to avoid duplication, when created, save the filename to session storage
-	const savedItems = sessionStorage.getItem("menu");
-	// if the session storage key doesn't exist use empty array
-	const activeItems = savedItems ? JSON.parse(savedItems) : [];
-	if (activeItems.indexOf(userscript.scriptObject.filename) !== -1) {
-		// if already saved, remove it, to get fresh code changes
-		await browser.menus.remove(userscript.scriptObject.filename);
-	}
-	// potential bug? https://developer.apple.com/forums/thread/685273
-	// https://stackoverflow.com/q/68431201
-	// parse through match values and change pathnames to deal with bug
 	const patterns = userscript.scriptObject.matches;
-	patterns.forEach((pattern, index) => {
-		try {
-			const url = new URL(pattern);
-			let pathname = url.pathname;
-			if (pathname.length > 1 && pathname.endsWith("/")) {
-				pathname = pathname.slice(0, -1);
-			}
-			patterns[index] = `${url.protocol}//${url.hostname}${pathname}`;
-		} catch (error) {
-			// prevent breaking when non-url pattern present
-			console.error(error);
-		}
-	});
-
 	browser.menus.create(
 		{
 			contexts: ["all"],
@@ -263,9 +237,6 @@ async function addContextMenuItem(userscript) {
 			if (!browser.menus.onClicked.hasListener(contextClick)) {
 				browser.menus.onClicked.addListener(contextClick);
 			}
-			// save the context-menu item reference to sessionStorage
-			const value = JSON.stringify([userscript.scriptObject.filename]);
-			sessionStorage.setItem("menu", value);
 		},
 	);
 }


### PR DESCRIPTION
 fix #743

In old Safari `browser.menus.remove` just failed silently for non-existent menu item, but in the latest version it rejects the promise, causes failed functional due to unhandled throw.

https://github.com/quoid/userscripts/blob/bca043a92023d5fa6226b9a17538393610a2a195/src/ext/background/main.js#L201-L204

Since all menu items are actually deleted every time, `sessionStorage` related logic is not necessary. So simply delete it.

Paths ending in `/` corresponding to different [Match patterns](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) are expected and can be avoided at the user level. There no need to handle it at the extension level, so the relevant logic is deleted.

Anyway, it's just a simple fix to get it basically working again.
But this feature needs to be completely redesigned and refactored.
- https://github.com/quoid/userscripts/issues/453

