### PR TITLE
fix: bypass extension page layout breakage

### DIFF
--- a/src/ext/extension-page/App.svelte
+++ b/src/ext/extension-page/App.svelte
@@ -73,10 +73,10 @@
 		{/if}
 	</div>
 {/if}
-<div>
+<main>
 	<Sidebar />
 	<Editor />
-</div>
+</main>
 <ul>
 	{#each $notifications as item (item.id)}
 		<Notification on:click={() => notifications.remove(item.id)} {item} />
@@ -115,7 +115,7 @@
 		font: var(--text-medium);
 	}
 
-	div:not(.initializer) {
+	main {
 		display: flex;
 		flex: 1 0 0;
 		overflow: hidden;

--- a/src/ext/extension-page/Appios.svelte
+++ b/src/ext/extension-page/Appios.svelte
@@ -79,12 +79,6 @@
 		font: var(--text-medium);
 	}
 
-	div:not(.initializer) {
-		display: flex;
-		flex: 1 0 0;
-		overflow: hidden;
-	}
-
 	ul {
 		bottom: 1rem;
 		left: 50%;


### PR DESCRIPTION
Fix the layout breakage mentioned in https://github.com/quoid/userscripts/issues/743#issuecomment-2439914723

<img width="1728" alt="sc" src="https://github.com/user-attachments/assets/9ed76591-e131-4ede-9f79-8f8a78f39ade">