### PR TITLE
fix: improve error catching of injected user scripts

### DIFF
--- a/src/ext/content-scripts/entry-userscripts.js
+++ b/src/ext/content-scripts/entry-userscripts.js
@@ -51,7 +51,7 @@ function injectJS(userscript) {
 ${userscript.code}
 // ===UserScript====end====
 	} catch (error) {
-		console.error(error);
+		console.error(\`${filename.replaceAll("`", "\\`")}\`, error);
 	}
 })(); //# sourceURL=${filename.replace(/[\s"']/g, "-") + usTag}`;
 	let injectInto = userscript.scriptObject["inject-into"];
@@ -86,7 +86,7 @@ ${userscript.code}
 				code,
 			)(userscript.apis);
 		} catch (error) {
-			console.error(error);
+			console.error(`${filename}`, error);
 		}
 		return;
 	}


### PR DESCRIPTION
- Fix async error not caught introduced by #750

- Fix errors may not show up in console when injecting page context
  - For example, the page script prevented the default event:
    ```js
    window.addEventListener('unhandledrejection', (event) => {
	    event.stopImmediatePropagation();
	    event.preventDefault();
    });
    ```

- Fix the `sourceURL` resource not show up when the script name contains quotation marks