### PR TITLE
chore: install globals as a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"eslint": "^9.23.0",
 				"eslint-config-prettier": "^10.1.1",
 				"eslint-plugin-svelte": "^3.3.3",
+				"globals": "^16.0.0",
 				"marked": "^15.0.7",
 				"prettier": "3.5.3",
 				"prettier-plugin-svelte": "3.3.3",
@@ -698,6 +699,19 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@eslint/js": {
@@ -2413,9 +2427,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
+			"integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"eslint": "^9.23.0",
 		"eslint-config-prettier": "^10.1.1",
 		"eslint-plugin-svelte": "^3.3.3",
+		"globals": "^16.0.0",
 		"marked": "^15.0.7",
 		"prettier": "3.5.3",
 		"prettier-plugin-svelte": "3.3.3",


### PR DESCRIPTION
https://www.npmjs.com/package/globals

The `globals` package should be installed manually and `ESLint` no longer updates the dependent version.

The previous configuration for ESLint 9 misunderstood this.