### PR TITLE
ci: update xcode version

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -38,7 +38,7 @@ jobs:
       - run: npm run build:${{ matrix.platform }}-safari-15
         if: ${{ ! github.event.release.prerelease }}
       - name: Set xcode version
-        run: sudo xcode-select -s "/Applications/Xcode_15.4.app" # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
+        run: sudo xcode-select -s "/Applications/Xcode_16.2.app" # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#xcode
       - name: Run fastlane
         id: fastlane
         working-directory: ./fastlane


### PR DESCRIPTION
fix ci error:
https://github.com/quoid/userscripts/actions/runs/15243392919
```sh
[!] Error uploading ipa file: 
[Application Loader Error Output]: ERROR: [ContentDelivery.Uploader] Validation failed (409) SDK version issue. This app was built with the iOS 17.5 SDK. All iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution. (ID: 3bc4c102-6f39-42f0-ae17-faf4eda74bd5)
[Application Loader Error Output]: Error uploading '/var/folders/w5/_8wgjw3j5cg6mgrth3s2kg9m0000gn/T/cbca1839-e1e9-418e-b1b4-081556fcabcf.ipa'.
[Application Loader Error Output]: Validation failed SDK version issue. This app was built with the iOS 17.5 SDK. All iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution. (ID: 3bc4c102-6f39-42f0-ae17-faf4eda74bd5) (409)
```