### PR TITLE
fix: editor tab key restores default behavior

### DIFF
--- a/src/ext/extension-page/Components/Editor/CodeMirror.svelte
+++ b/src/ext/extension-page/Components/Editor/CodeMirror.svelte
@@ -150,11 +150,6 @@
 				"Cmd-S": () => saveHandler(),
 				"Cmd-F": () => activateSearch(),
 				Esc: () => (searchActive = false),
-				Tab: (cm) => {
-					// convert tabs to spaces and add invisible elements
-					const s = Array(cm.getOption("indentUnit") + 1).join(" ");
-					cm.replaceSelection(s);
-				},
 			},
 		});
 


### PR DESCRIPTION
resolve #841

Delete the custom Tab handler and restore the default behavior.